### PR TITLE
Reorder TrigramFeatures.trigram_subtype for onehands

### DIFF
--- a/granite_tools/trigram_features.py
+++ b/granite_tools/trigram_features.py
@@ -99,8 +99,8 @@ class TrigramFeatures:
             pt
             for pt in (
                 self.easy_rolling,
-                self.redir,
                 self.single_finger_pattern,
+                self.redir,
                 self.vert2u,
             )
             if pt

--- a/tests/test_trigram_features.py
+++ b/tests/test_trigram_features.py
@@ -95,7 +95,8 @@ class TestTrigramFeatures:
         [
             # fmt: off
             (("onehand", "SFB", "v1x", None, None), "SFB-v1x"),
-            (("onehand", "SFB", None, "redir", None), "redir-SFB"),
+            (("onehand", "SFB", None, "redir", None), "SFB-redir"),
+            (("onehand", "SFB", "v2x", "redir", None), "SFB-redir-v2x"),
             (("balanced", None, None, None, None), "balanced"),
             (("onehand", None, None, None, None), "onehand"),
             (("onehand", None, None, None, "easy-rolling"), "easy-rolling"),


### PR DESCRIPTION
Previously, redir was listed before SFB
Now, list SFB before redir (e.g. SFB-redir-v1x)

This means in practice that the parts of trigram subtype
(for onehand trigrams) is ordered by relative importance

First easy-rolling, if any
then SFB/SFT/SFS if any
then redir if any
and lastly v2x or v1x if any.