### PR TITLE
trigram_subtype naming: Use dot instead of a dash as a separator

### DIFF
--- a/granite_tools/trigram_features.py
+++ b/granite_tools/trigram_features.py
@@ -105,7 +105,7 @@ class TrigramFeatures:
             )
             if pt
         )
-        return "-".join(parts)
+        return ".".join(parts)
 
 
 def get_single_finger_pattern(

--- a/tests/test_trigram_features.py
+++ b/tests/test_trigram_features.py
@@ -94,14 +94,14 @@ class TestTrigramFeatures:
         "args, trigram_subtype",
         [
             # fmt: off
-            (("onehand", "SFB", "v1x", None, None), "SFB-v1x"),
-            (("onehand", "SFB", None, "redir", None), "SFB-redir"),
-            (("onehand", "SFB", "v2x", "redir", None), "SFB-redir-v2x"),
+            (("onehand", "SFB", "v1x", None, None), "SFB.v1x"),
+            (("onehand", "SFB", None, "redir", None), "SFB.redir"),
+            (("onehand", "SFB", "v2x", "redir", None), "SFB.redir.v2x"),
             (("balanced", None, None, None, None), "balanced"),
             (("onehand", None, None, None, None), "onehand"),
             (("onehand", None, None, None, "easy-rolling"), "easy-rolling"),
             # hypothetical (easy-rolling) trigram with v1x flag
-            (("onehand", None, "v1x", None, "easy-rolling"), "easy-rolling-v1x"),
+            (("onehand", None, "v1x", None, "easy-rolling"), "easy-rolling.v1x"),
             # fmt: on
         ],
     )


### PR DESCRIPTION
Use dot (.) as separator instead of dash (-)

Reason: One of the parts is called easy-rolling
which has a dash in it.