### PR TITLE
Trigram subtypes

### DIFF
--- a/granite_tools/trigram_features.py
+++ b/granite_tools/trigram_features.py
@@ -105,7 +105,7 @@ class TrigramFeatures:
             )
             if pt
         )
-        return ".".join(parts)
+        return "|".join(parts)
 
 
 def get_single_finger_pattern(

--- a/granite_tools/trigram_features.py
+++ b/granite_tools/trigram_features.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 from dataclasses import dataclass
-from typing import Literal, Sequence
+from typing import ClassVar, Literal, Sequence
 
 from granite_tools.app_types import FingerType, HandOrKey, Vert2uPenaltyConfig
 from granite_tools.easy_rolling import get_easy_rolling_type_mapping
@@ -28,6 +28,8 @@ class TrigramFeatures:
     vert2u: Vert2uFeatureFlag = None
     redir: RedirFeatureFlag = None
     easy_rolling: EasyRollingFeatureFlag = None
+
+    sep: ClassVar[str] = "|"
 
     @classmethod
     def from_string(
@@ -95,6 +97,7 @@ class TrigramFeatures:
             raise RuntimeError(
                 'Expecting only "onehand" trigram type to have any additional feature flags.'
             )
+
         parts = (
             pt
             for pt in (
@@ -105,7 +108,12 @@ class TrigramFeatures:
             )
             if pt
         )
-        return "|".join(parts)
+
+        name = self.sep.join(parts)
+        if name in ("v1x", "v2x"):
+            # keep onehand text in the name
+            return f"onehand{self.sep}{name}"
+        return name
 
 
 def get_single_finger_pattern(

--- a/tests/test_trigram_features.py
+++ b/tests/test_trigram_features.py
@@ -102,6 +102,8 @@ class TestTrigramFeatures:
             (("onehand", None, None, None, "easy-rolling"), "easy-rolling"),
             # hypothetical (easy-rolling) trigram with v1x flag
             (("onehand", None, "v1x", None, "easy-rolling"), "easy-rolling|v1x"),
+            # A special case where the onehand prefix is preserved
+            (("onehand", None, "v1x", None, None), "onehand|v1x"),
             # fmt: on
         ],
     )

--- a/tests/test_trigram_features.py
+++ b/tests/test_trigram_features.py
@@ -94,14 +94,14 @@ class TestTrigramFeatures:
         "args, trigram_subtype",
         [
             # fmt: off
-            (("onehand", "SFB", "v1x", None, None), "SFB.v1x"),
-            (("onehand", "SFB", None, "redir", None), "SFB.redir"),
-            (("onehand", "SFB", "v2x", "redir", None), "SFB.redir.v2x"),
+            (("onehand", "SFB", "v1x", None, None), "SFB|v1x"),
+            (("onehand", "SFB", None, "redir", None), "SFB|redir"),
+            (("onehand", "SFB", "v2x", "redir", None), "SFB|redir|v2x"),
             (("balanced", None, None, None, None), "balanced"),
             (("onehand", None, None, None, None), "onehand"),
             (("onehand", None, None, None, "easy-rolling"), "easy-rolling"),
             # hypothetical (easy-rolling) trigram with v1x flag
-            (("onehand", None, "v1x", None, "easy-rolling"), "easy-rolling.v1x"),
+            (("onehand", None, "v1x", None, "easy-rolling"), "easy-rolling|v1x"),
             # fmt: on
         ],
     )


### PR DESCRIPTION
1) Change the subtype separator again

From dot (.) to pipe (|). Reasoning: The parts of the
name are flags, so it kind of makes sense to use pipes
as separators?

2) Rename subtypes

v1x -> onehand|v1x
v2x -> onehand|v2x

Now the subtypes are (grouped by the first part of the name):

  easy-rolling   

  balanced       

  alternating    

  onehand        
  onehand|v1x            
  onehand|v2x            

  redir          
  redir|v1x      
  redir|v2x      

  SFB            
  SFB|v1x        
  SFB|v2x        
  SFB|redir      
  SFB|redir|v1x  
  SFB|redir|v2x  

  SFS            
  SFS|v1x        
  SFS|redir      
  SFS|redir|v1x  
  SFS|redir|v2x  
  SFSb           
  SFSb|v2x       

  SFT              
  SFT|v1x        
  SFT|v2x
  SFTb           
  SFTb|v2x   