### PR TITLE
granite-trigram-model-fit-check

### DIFF
--- a/docs/scoring-key-efforts.md
+++ b/docs/scoring-key-efforts.md
@@ -296,9 +296,14 @@ Use `granite-trigram-model-fit` to fit the trigram coefficients.
 **Example**:
 
 ```
-granite-trigram-model-fit examples/config.yml tmp/efforts.ranking tmp/trigram.relative.toml
+granite-trigram-model-fit examples/config.yml tmp/granite.bigram.ranking tmp/bigram-anchor-scores-raw.json tmp/granite.trigram.scoreratios.yml
 ```
 
+the results can be checked with:
+
+```
+granite-trigram-model-fit-check examples/config.yml tmp/granite.bigram.ranking tmp/bigram-anchor-scores-raw.json tmp/granite.trigram.scoreratios.yml
+```
 
 ## granite-bigram-ranking-view
 

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -117,15 +117,15 @@ u_weight_alternating: 0.1
 vert2u_coeff: 0.115
 
 # Fitted parameters:
-easy_rolling_coeff: 0.605
-balanced_coeff: 0.930
-alternating_coeff: 1.227
-redir_coeff: 1.432
-sfb_in_onehand_coeff: 1.871
-sft_coeff: 1.951
-sftb_coeff: 2.115
-sfs_coeff: 1.364
-sfsb_coeff: 1.234
+easy_rolling_coeff: 0.572
+balanced_coeff: 0.879
+alternating_coeff: 1.221
+redir_coeff: 1.415
+sfb_in_onehand_coeff: 1.929
+sft_coeff: 1.927
+sftb_coeff: 2.089
+sfs_coeff: 1.347
+sfsb_coeff: 1.219
 
 # This is used for trigram model fitting process (ADVANCED SETTING)
 # With this you tell the uncertainty of the trigram score ratios in the trigram score ratio file

--- a/granite_tools/trigram_model/data.py
+++ b/granite_tools/trigram_model/data.py
@@ -75,7 +75,7 @@ def get_trigram_data(
             fingers, _ = hands.get_fingers(d["trigram"])
             has_thumb = FingerType.T in fingers
             data["has_thumb"].append(has_thumb)
-            meta = d.pop("estimated_score_details")
+            meta = d.pop("trigram_score_details")
             data["trigram_type"].append(meta["trigramtype"])
             data["ngram1"].append(meta["ngram1_score"])
             data["ngram2"].append(meta["ngram2_score"])

--- a/granite_tools/trigram_model/plotting.py
+++ b/granite_tools/trigram_model/plotting.py
@@ -4,15 +4,17 @@ import typing
 from pathlib import Path
 
 from matplotlib import pyplot as plt
+from matplotlib.ticker import MaxNLocator
 
 from granite_tools.easy_rolling import get_easy_rolling_type_mapping
+from granite_tools.trigram_features import TrigramFeatures
 from granite_tools.trigram_types import get_trigram_type
 
 if typing.TYPE_CHECKING:
     from granite_tools.hands import Hands
     from granite_tools.trigram_model.scorer import TrigramScoreDict
 
-DUMBBELL_PLOT_ONE_ROW_HEIGHT = 0.27
+DUMBBELL_PLOT_ONE_ROW_HEIGHT = 0.8
 
 TRIGRAM_TYPE_COLORS = {
     "balanced": "#008f5d",
@@ -23,84 +25,97 @@ TRIGRAM_TYPE_COLORS = {
 
 
 def plot_trigram_scores(
-    groups: dict[str, list[TrigramScoreDict]],
+    scores: list[TrigramScoreDict],
     hands: Hands,
     outfile: Path,
-    trigram_type: str = "all",
 ):
     """Plots trigram scores and saves the plot to a file.
 
     Parameters
     ----------
-    groups : dict[str, list[TrigramScoreDict]]
-        A dictionary with group names as keys and lists of trigram score dictionaries as values.
+    scores : list[TrigramScoreDict]
+        The trigram score data.
     hands : Hands
         The hands data (from configuration file).
     outfile : Path
         Where to save the plot.
-    trigram_type : str
-        The trigram type to plot. Default is "all". Other options are
-        "balanced", "onehand", "redir", and "alternating". Note that only the non-reference
-        trigrams are plotted since the reference trigrams are always scores 1.0 without
-        any error. The reference trigrams are the FIRST trigrams of each trigram family
-        in the trigram scoring file.
     """
-    fig, ax = plt.subplots()
-    ax2 = ax.twiny()
-    plt.sca(ax)
+    fig, axes = plt.subplots(nrows=1, ncols=2)
+    ax_left, ax_right = axes
+    ax_left_upper = ax_left.twiny()
+    ax_right_upper = ax_right.twiny()
+    plt.sca(ax_left)
 
-    n_items = 0
-    y_tick_labels: list[str] = []
-    # TODO: is the mapping needed anymore?
-    mapping = get_easy_rolling_type_mapping(hands.config.easy_rolling_trigrams, hands)
-    for i, (_, scoredicts) in enumerate(groups.items()):
-        row_is_odd = i % 2 == 1
-        for d in reversed(scoredicts):
+    yticklabels_left = []
+    yticklabels_right = []
+    yticks = []
+    gap_between_bars = 0.1
+    width_of_bars = 0.25
+    bar_displacement = (width_of_bars + gap_between_bars) / 2
 
-            type_of_trigram = get_trigram_type(d["trigram"], hands)
-            linecolor = TRIGRAM_TYPE_COLORS[type_of_trigram]
-            if trigram_type != "all" and trigram_type != type_of_trigram:
-                continue
-            n_items += 1
-            y = n_items
-            y_tick_labels.append(
-                f'{d["trigram"]} ({type_of_trigram}, {d['reference_trigram']})'
-            )
-            marker = "o" if row_is_odd else "s"
+    for i, scoredct in enumerate(scores[::-1], start=1):
+        trigram_score = scoredct["trigram_score_details"]["score"]
+        trigram_type = scoredct["trigram_score_details"]["trigramtype"]
+        ref_score = scoredct["reference_score_details"]["score"]
+        ref_type = scoredct["reference_score_details"]["trigramtype"]
+        score_ratio_act = scoredct["score_ratio_actual"]
+        score_ratio_pred = scoredct["score_ratio_pred"]
+        trigram = scoredct["trigram"]
+        ref_trigram = scoredct["reference_trigram"]
 
-            ax.scatter(
-                d["score_ratio_actual"],
-                y,
-                color="cornflowerblue" if row_is_odd else "tab:blue",
-                label="Target (manual)" if n_items == 1 else None,
-                marker=marker,
-            )
-            ax.scatter(
-                d["score_ratio_pred"],
-                y,
-                color="tomato" if row_is_odd else "tab:red",
-                label="Model" if n_items == 1 else None,
-                marker=marker,
-            )
+        features = TrigramFeatures.from_string(trigram, hands, None, True)
+        ref_features = TrigramFeatures.from_string(ref_trigram, hands, None, True)
 
-            ax.plot(
-                (d["score_ratio_actual"], d["score_ratio_pred"]),
-                (y, y),
-                color=linecolor,
-                lw=1.0,
-                zorder=-10,
-            )
+        ax_left.scatter(
+            score_ratio_act,
+            i,
+            facecolors="none",
+            edgecolor="black",
+            s=30,
+            marker="o",
+            zorder=10,
+        )
+        ax_left.scatter(score_ratio_pred, i, color="red", s=15, zorder=20)
 
-    ax.set_yticks(list(range(1, n_items + 1)), labels=y_tick_labels)
+        ax_right.barh(
+            i + bar_displacement,
+            trigram_score,
+            color="darkgray",
+            height=0.25,
+            zorder=10,
+        )
+        ax_right.barh(
+            i - bar_displacement,
+            ref_score,
+            color="gray",
+            height=0.25,
+            zorder=10,
+        )
+        yticklabels_left.append(
+            f"{trigram}/{ref_trigram}\n({features.trigram_subtype}/{ref_features.trigram_subtype})"
+        )
+        yticklabels_right.append(
+            f"{trigram} ({features.trigram_subtype})\n\n{ref_trigram} ({ref_features.trigram_subtype})"
+        )
+        yticks.append(i)
 
+    ax_left.set_yticks(yticks, yticklabels_left)
+
+    fig.set_size_inches(12, 4 + DUMBBELL_PLOT_ONE_ROW_HEIGHT * len(scores))
+    plt.grid(axis="x", linestyle="--", color="lightgray", zorder=-100)
+    plt.axvline(x=1.0, color="black", linestyle="-", lw=0.5, zorder=2)
     # Make the secondary x-axis at the top same as the main x-axis at the bottom
-    ax2.set_xticks(ax.get_xticks())
-    ax2.set_xlim(ax.get_xlim())
+    ax_left_upper.set_xlim(ax_left.get_xlim())
+    ax_left.xaxis.set_major_locator(MaxNLocator(integer=True))
+    ax_left_upper.set_xticks(ax_left.get_xticks(), ax_left.get_xticklabels())
+    ax_left.set_xticks(ax_left_upper.get_xticks(), ax_left_upper.get_xticklabels())
+    ax_left.set_xlabel("Score ratio")
 
-    ax.set_ylim(0, n_items + 1)
-    plt.legend(loc="upper left")
-    ax.grid(axis="x", linestyle="--", color="lightgray")
-    fig.set_size_inches(20, 4 + DUMBBELL_PLOT_ONE_ROW_HEIGHT * n_items)
+    ax_right.grid(axis="x", linestyle="--", color="lightgray", zorder=-100)
+    ax_right.xaxis.set_major_locator(MaxNLocator(integer=True))
+    ax_right_upper.set_xticks(ax_right.get_xticks(), ax_right.get_xticklabels())
+    ax_right.set_yticks(yticks, yticklabels_right)
+    ax_right.set_xlabel("Score")
     plt.tight_layout()
     plt.savefig(str(outfile), dpi=150)
     print("Plot saved to", outfile)

--- a/granite_tools/trigram_model/scorer.py
+++ b/granite_tools/trigram_model/scorer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing
 
 from granite_tools.app_types import HAND_TYPES
+from granite_tools.easy_rolling import get_easy_rolling_type_mapping
 from granite_tools.trigram_features import TrigramFeatures
 from granite_tools.trigram_model.params import TrigramModelParameters
 from granite_tools.trigram_types import UnTypableTrigramError
@@ -306,7 +307,7 @@ class TrigramScoreDict(typing.TypedDict):
     score_ratio_actual: float
     score_ratio_pred: float
     estimated_score: float
-    estimated_score_details: dict
+    trigram_score_details: dict
 
 
 def get_trigram_scores(
@@ -340,6 +341,10 @@ def get_trigram_scores(
           model. This is also scaled by dividing by the score of the reference trigram.
           In other words, it is model_score(trigram)/model_score(reference_trigram).
     """
+
+    mapping = mapping or get_easy_rolling_type_mapping(
+        hands.config.easy_rolling_trigrams, hands
+    )
 
     def get_trigram_score_(trigram: str) -> dict:
         """Convenience function which handles expection(s) and makes it easier to call
@@ -375,7 +380,8 @@ def get_trigram_scores(
                 score_ratio_actual=entry["score_ratio"],
                 score_ratio_pred=score_ratio_pred,
                 estimated_score=estimated_score,
-                estimated_score_details=estimated_score_dct,
+                trigram_score_details=estimated_score_dct,
+                reference_score_details=ref_score_dct,
             )
         )
 


### PR DESCRIPTION
1. Fix granite-trigram-model-fit-check command
* This was broken due to previous refactoring

2. The granite-trigram-model-fit-check shows a new type of plot
* On the left, the score ratio (predicted, actual)
* One the right, scores of the trigrams (trigram and the ref trigram)
  as a bar plot.