### PR TITLE
fix: asymmetric weights in optimization

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -117,15 +117,15 @@ u_weight_alternating: 0.1
 vert2u_coeff: 0.115
 
 # Fitted parameters:
-easy_rolling_coeff: 0.555
-balanced_coeff: 0.866
-alternating_coeff: 1.205
-redir_coeff: 1.417
-sfb_in_onehand_coeff: 1.919
-sft_coeff: 1.962
-sftb_coeff: 2.242
-sfs_coeff: 1.355
-sfsb_coeff: 1.253
+easy_rolling_coeff: 0.471
+balanced_coeff: 0.735
+alternating_coeff: 1.193
+redir_coeff: 1.533
+sfb_in_onehand_coeff: 2.189
+sft_coeff: 2.123
+sftb_coeff: 2.426
+sfs_coeff: 1.466
+sfsb_coeff: 1.355
 
 # This is used for trigram model fitting process (ADVANCED SETTING)
 # With this you tell the uncertainty of the trigram score ratios in the trigram score ratio file


### PR DESCRIPTION
Fixes the asymmetric weighting calculation during optimization. 

Previously, the weighting seemed to use the inverse of the limits for the score ratio as the weight. Now it uses "estimated variance". 

The asymmetric weighting means that the positive errors are allowed to be larger than negative errors. This is because score ratios have hard minimum at zero and negative error size must be limited; the loss function is asymmetric.

This hasn't yet been proved to be a good idea in practice. If this does not work, one idea is to use same weights for positive and negative errors. Need to investigate this a bit more. 