### PR TITLE
Bigram score plots: Multiple annotations and --short/--long option

### DIFF
--- a/granite_tools/bigram_scores/cli.py
+++ b/granite_tools/bigram_scores/cli.py
@@ -300,7 +300,7 @@ ARG_BIGRAM_SCORE_FILE = Annotated[
 ]
 
 ARG_SHORT_OR_LONG_ANNOTATIONS = Annotated[
-    Optional[bool],
+    bool,
     typer.Option(
         "--short/--long",
         help="Whether to show short or long form of the annotations.",

--- a/granite_tools/bigram_scores/cli.py
+++ b/granite_tools/bigram_scores/cli.py
@@ -8,6 +8,7 @@ import time
 import typing
 from collections import defaultdict
 from pathlib import Path
+from typing import Optional
 
 import pandas as pd
 import typer
@@ -298,13 +299,23 @@ ARG_BIGRAM_SCORE_FILE = Annotated[
     ),
 ]
 
+ARG_SHORT_OR_LONG_ANNOTATIONS = Annotated[
+    Optional[bool],
+    typer.Option(
+        "--short/--long",
+        help="Whether to show short or long form of the annotations.",
+        show_default=True,
+    ),
+]
+
 
 def bigram_scores_plot_(
     bigram_score_file: ARG_BIGRAM_SCORE_FILE = DEFAULT_SCORE_FILE_OUT,
+    short_annotations: ARG_SHORT_OR_LONG_ANNOTATIONS = True,  # True means "--short"
 ):
     """Plot bigram scores from a bigram score JSON file."""
     bigram_scores = read_bigram_scores(bigram_score_file)
-    plot_bigram_scores(bigram_scores)
+    plot_bigram_scores(bigram_scores, short_annotations=short_annotations)
     plt.show()
 
 

--- a/granite_tools/bigram_scores/plotting.py
+++ b/granite_tools/bigram_scores/plotting.py
@@ -89,7 +89,7 @@ def plot_bigram_scores(scores: list[BigramScoreDict]):
         ax.grid(ls="--", lw=0.5, color="lightgray", zorder=-10)
 
     plt.tight_layout()
-    cur = cursor(figure, hover=True)
+    cur = cursor(figure, hover=False, multiple=True)
 
     def set_annotation_text(sel: Selection):
         add_relative_score = False

--- a/granite_tools/bigram_scores/plotting.py
+++ b/granite_tools/bigram_scores/plotting.py
@@ -66,7 +66,7 @@ def plot_bigram_scores(scores: list[BigramScoreDict], short_annotations: bool = 
         [s["score"] for s in unigrams],
         marker=".",
         s=122,
-        color="tab:blue",
+        color="tab:red",
         zorder=10,
     )
     ax_unigram.set_xlabel("Rank of unigram")
@@ -128,7 +128,9 @@ def plot_bigram_scores(scores: list[BigramScoreDict], short_annotations: bool = 
 
         sel.annotation.set_text(annotation_text)
         sel.annotation.set_fontfamily("monospace")
-        sel.annotation.set_bbox(dict(boxstyle="round,pad=0.3", fc="white", ec="black"))
+        sel.annotation.set_bbox(dict(boxstyle="round,pad=0.38", fc="white", ec="black"))
+        sel.annotation.set_alpha(0.8)
+        sel.annotation.set_fontsize("x-small")
 
     cur.connect("add", set_annotation_text)
 

--- a/granite_tools/bigram_scores/plotting.py
+++ b/granite_tools/bigram_scores/plotting.py
@@ -128,7 +128,9 @@ def plot_bigram_scores(scores: list[BigramScoreDict], short_annotations: bool = 
 
         sel.annotation.set_text(annotation_text)
         sel.annotation.set_fontfamily("monospace")
-        sel.annotation.set_bbox(dict(boxstyle="round,pad=0.38", fc="white", ec="black"))
+        sel.annotation.set_bbox(
+            dict(boxstyle="round4,pad=0.58", fc="white", ec="black")
+        )
         sel.annotation.set_alpha(0.8)
         sel.annotation.set_fontsize("x-small")
 

--- a/granite_tools/bigram_scores/plotting.py
+++ b/granite_tools/bigram_scores/plotting.py
@@ -51,7 +51,7 @@ def plot_anchor_scores(ngrams_ordered: list[KeySeq], scores: dict[KeySeq, float]
     plt.title("Bigram scores (raw, unscaled)")
 
 
-def plot_bigram_scores(scores: list[BigramScoreDict]):
+def plot_bigram_scores(scores: list[BigramScoreDict], short_annotations: bool = True):
     """Plots bigram (and unigram) scores."""
     bigrams = [s for s in scores if s["type"] == "bigram"]
     unigrams = [s for s in scores if s["type"] == "unigram"]
@@ -102,19 +102,33 @@ def plot_bigram_scores(scores: list[BigramScoreDict]):
             return
         dct = scores[sel.index]
 
-        labels = [
-            f"left: {dct['__comment__left']}",
-            f"right: {dct['__comment__right']}",
-            f"score: {dct['score']:.2f}",
-            f"rank: {dct['rank_type']}",
-            f"key_indices: {dct['key_indices']}",
-        ]
+        left = dct.get("__comment__left", "??")
+        right = dct.get("__comment__right", "??")
+        score = f"{dct.get('score', 0):.2f}"
+        rank = "#" + str(dct.get("rank_type", "??"))
 
-        if add_relative_score:
-            ref_score = scores[0]["score"]
-            labels.insert(3, f"relative_score: {dct['score']/ref_score:.2f}")
+        if short_annotations:
+            max_len = max(len(score), len(rank))
+            upper = f"{left} {score.rjust(max_len)}"
+            lower = f"{right} {rank.rjust(max_len)}"
+            annotation_text = f"{upper}\n{lower}"
+        else:
+            labels = [
+                f"left: {left}",
+                f"right: {right}",
+                f"score: {score}",
+                f"rank: {rank}",
+                f"key_indices: {dct.get('key_indices', '??')}",
+            ]
 
-        sel.annotation.set_text("\n".join(labels))
+            if add_relative_score:
+                ref_score = scores[0]["score"]
+                labels.insert(3, f"relative_score: {dct['score']/ref_score:.2f}")
+            annotation_text = "\n".join(labels)
+
+        sel.annotation.set_text(annotation_text)
+        sel.annotation.set_fontfamily("monospace")
+        sel.annotation.set_bbox(dict(boxstyle="round,pad=0.3", fc="white", ec="black"))
 
     cur.connect("add", set_annotation_text)
 


### PR DESCRIPTION
Improve the Bigram Scores Plot annotations

* Add possibility to add multiple annotations to the plot (removes to auto-label on hover)
* Added --short/--long option to granite-bigram-scores-plot. Defaults to --short if not given. The new --short option makes the annotation boxes much smaller

Example
-------
    granite-bigram-scores-plot data/bigram.scores.json --long

Uses the (old) long format of annotations. Defaults to --short if not given.


Example of multiple annotations
-------------------------------

![new-bigram-scores-annotated](https://github.com/user-attachments/assets/6b403a14-81c3-4a08-bebb-042c797b2323)



